### PR TITLE
Add localstack support

### DIFF
--- a/vars/fxJob.groovy
+++ b/vars/fxJob.groovy
@@ -26,6 +26,7 @@ def call(Map closures = [:], List propertiesConfig = [], Map config = [:]) {
   mapAttributeCheck(config, 'podVolumes', List, [])
   mapAttributeCheck(config, 'preCommitDockerImageName', CharSequence, 'fxinnovation/pre-commit:latest')
   mapAttributeCheck(config, 'runKind', Boolean, false)
+  mapAttributeCheck(config, 'runLocalstack', Boolean, false)
   mapAttributeCheck(config, 'slaveSize', CharSequence, 'large')
   mapAttributeCheck(config, 'timeoutTime', Integer, 10)
   mapAttributeCheck(config, 'timeoutUnit', CharSequence, 'HOURS')
@@ -143,11 +144,32 @@ https://github.com/pulls?q=is%3Apr+created%3A%3E%3D2022-03-06+user%3AFXinnovatio
     resourceLimitMemory: slaveSizes.large.resourceLimitMemory,
   )
 
+  def localstackContainerTemplate = containerTemplate(
+    name: 'localstack',
+    image: "localstack/localstack:latest",
+    envVars: [
+      envVar(key: 'DOCKER_HOST', value: 'unix:///var/run/docker.sock'),
+    ],
+    command: '/bin/bash -c "cd /opt/code/localstack; docker-entrypoint.sh"',
+    ports: [portMapping(name: 'localstack', containerPort: 4566)],
+    resourceRequestCpu: slaveSizes.small.resourceRequestCpu,
+    resourceLimitCpu: slaveSizes.small.resourceLimitCpu,
+    resourceRequestMemory: slaveSizes.small.resourceRequestMemory,
+    resourceLimitMemory: slaveSizes.small.resourceLimitMemory,
+  )
+
   def podContainers = [jnlpContainerTemplate]
   def podInit = ""
 
   if (config.runKind && !IOC.get('JENKINS_LOCAL')) {
     podContainers << kindContainerTemplate
+  }
+
+  if (config.runLocalstack && !IOC.get('JENKINS_LOCAL')) {
+    podContainers << localstackContainerTemplate
+  }
+
+  if (!IOC.get('JENKINS_LOCAL') && (config.runLocalstack || config.runKind)) {
     podInit = """
 apiVersion: v1
 kind: Pod
@@ -337,6 +359,14 @@ private def pipeline(Map config, Map closures) {
         stage('kindlogs') {
           containerLog(
             name: 'kind'
+          )
+        }
+      }
+
+      if (config.runLocalstack && !IOC.get('JENKINS_LOCAL')) {
+        stage('localstacklogs') {
+          containerLog(
+            name: 'localstack'
           )
         }
       }

--- a/vars/standardTerraform.groovy
+++ b/vars/standardTerraform.groovy
@@ -53,6 +53,15 @@ def call(Map config = [:], Map closures = [:]) {
 
     def kindDockerVolume = [:]
     def terraformNetwork = 'bridge'
+
+    try {
+      if (config.runLocalstack) {
+        execute(
+          script: "docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack"
+        )
+      }
+    }
+
     try {
       if (config.runKind) {
         execute(

--- a/vars/standardTerraform.groovy
+++ b/vars/standardTerraform.groovy
@@ -55,14 +55,6 @@ def call(Map config = [:], Map closures = [:]) {
     def terraformNetwork = 'bridge'
 
     try {
-      if (config.runLocalstack) {
-        execute(
-          script: "docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack"
-        )
-      }
-    }
-
-    try {
       if (config.runKind) {
         execute(
           script: """


### PR DESCRIPTION
Allow an option to run localstack in terraform pipelines

Add runLocalstack: true in the jenkinsfile will spawn an ephemeral localstack

you can then update the AWS provider to use localstack:

```hcl
provider "aws" {
  s3_use_path_style           = true
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  skip_requesting_account_id  = true

  endpoints {
    ec2  = "http://localhost:4566"
    route53 = "http://localhost:4566"
  }
}
```

Resource: https://docs.localstack.cloud/integrations/terraform/#request-management